### PR TITLE
Update vector_search.md

### DIFF
--- a/autonomous_database/vector_search/vector_search.md
+++ b/autonomous_database/vector_search/vector_search.md
@@ -656,7 +656,7 @@ You can load your own PDFs into Object Storage if you like.  If you would like t
 	end;
 
 	v_resp := dbms_cloud.send_request(
-	credential_name => v_ociapi_credential,
+	credential_name => v_vector_credential,
 	uri => v_gen_ai_endpoint || v_chat_endpoint,
 	method => dbms_cloud.method_post,
 	body => utl_raw.cast_to_raw(json_object(


### PR DESCRIPTION
Line 772 references the wrong credential. to call the gen API credential you need to leverage the variable v_vector_credential as opposed to v_ociapi_credential otherwise you get an credential error when execute the queries with the function calls.